### PR TITLE
Footer size fix for iphone and ipad

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -303,6 +303,8 @@ width:70px;
 {
 padding:10px;
 font-size:12px;
+-webkit-text-size-adjust:none;
+
 }
 
 


### PR DESCRIPTION
Added a webkit text size adjust funtion in style.css to ensure correct displaying of footer without scaling on ios devices;